### PR TITLE
DOC-14284: Update Vale view for OpenAPI specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ attribute-missing = drop
 
 [*.{adoc}]
 BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
+
+[*.{yml,yaml}]
+View = OpenAPI
+BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
 ```
 
 5. Inside the quotation marks for the `StylesPath`, enter the location on your computer of the `ValeStyles` folder in this repository. 

--- a/ValeStyles/.vale.ini
+++ b/ValeStyles/.vale.ini
@@ -31,10 +31,6 @@ Vale.Spelling = NO
 [*.{adoc,md,txt}]
 BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
 
-[*.{yml,yaml}]
-View = OpenAPI
-BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
-
 [test/fixtures/test.yml]
 BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
 View = OpenAPIInclude

--- a/ValeStyles/.vale.ini
+++ b/ValeStyles/.vale.ini
@@ -31,6 +31,10 @@ Vale.Spelling = NO
 [*.{adoc,md,txt}]
 BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
 
+[*.{yml,yaml}]
+View = OpenAPI
+BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
+
 [test/fixtures/test.yml]
 BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
 View = OpenAPIInclude

--- a/ValeStyles/config/views/OpenAPI.yml
+++ b/ValeStyles/config/views/OpenAPI.yml
@@ -1,13 +1,13 @@
 engine: dasel
 scopes:
-  - expr: 'search(has("title")).map(title)'
+  - expr: '..title'
     name: title
     type: md
 
-  - expr: 'search(has("description")).map(description)'
+  - expr: '..description'
     name: description
     type: md
 
-  - expr: 'search(has("summary")).map(summary)'
+  - expr: '..summary'
     name: summary
     type: md

--- a/ValeStyles/config/views/OpenAPI.yml
+++ b/ValeStyles/config/views/OpenAPI.yml
@@ -1,4 +1,13 @@
 engine: dasel
 scopes:
-  - expr: properties.all().property(description?)
+  - expr: 'search(has("title")).map(title)'
+    name: title
+    type: md
+
+  - expr: 'search(has("description")).map(description)'
+    name: description
+    type: md
+
+  - expr: 'search(has("summary")).map(summary)'
+    name: summary
     type: md


### PR DESCRIPTION
Docs issue: [DOC-14284](https://jira.issues.couchbase.com/browse/DOC-14284)

This PR updates the `OpenAPI` view to tell Vale to check `title`, `summary`, and `description` elements, wherever they occur. These elements are hard to detect because they can occur at arbitrary depths in an OpenAPI spec.

To find these elements, this view depends on the Dasel `search` function, which is only available in Dasel 3 or later. Dasel 3 is included in Vale 3.14.1. So, in order to make use of this view, you must be using Vale version 3.14.1 or later.

To test, add the following to the end of your `.vale.ini`:

```ini
[*.{yml,yaml}]
View = OpenAPI
BasedOnStyles = Vale, write-good, proselint, Couchbase, Google
```
# Test

Using `analytics-admin.yaml` in the [cb-swagger](https://github.com/couchbaselabs/cb-swagger) repo:

```console
$ vale --minAlertLevel=error analytics-admin.yaml

 analytics-admin.yaml
 9:64     error  Use 'Analytics Service'         Vale.Terms             
                 instead of 'Analytics                                  
                 service'.                                              
 10:54    error  Use 'Analytics Service'         Vale.Terms             
                 instead of 'Analytics                                  
                 service'.                                              
 53:64    error  Use 'that's' instead of 'that   Couchbase.Contractions 
                 is'.                                                   
 185:59   error  Use 'Analytics Service'         Vale.Terms             
                 instead of 'Analytics                                  
                 service'.                                              
 208:95   error  Use 'Analytics Service'         Vale.Terms             
                 instead of 'Analytics                                  
                 service'.                                              
 233:71   error  Use 'Analytics Service'         Vale.Terms             
                 instead of 'Analytics                                  
                 service'.                                              
 301:73   error  Write all numbers as numerals.  Couchbase.Numbers      
 306:73   error  Write all numbers as numerals.  Couchbase.Numbers      
 414:90   error  Write all numbers as numerals.  Couchbase.Numbers      
 439:96   error  Write all numbers as numerals.  Couchbase.Numbers      
 512:73   error  Write all numbers as numerals.  Couchbase.Numbers      
 543:54   error  Did you really mean 'seqno'?    Vale.Spelling          
 550:72   error  Use 'that's' instead of 'that   Couchbase.Contractions 
                 is'.                                                   
 554:23   error  Don't use 'note that.' Convert  Couchbase.NoteThat     
                 to an actual NOTE, or don't                            
                 use it at all.                                         
 566:60   error  Write all numbers as numerals.  Couchbase.Numbers      
 584:66   error  Write all numbers as numerals.  Couchbase.Numbers      
 601:39   error  Write all numbers as numerals.  Couchbase.Numbers      
 601:73   error  Write all numbers as numerals.  Couchbase.Numbers      
 614:32   error  Write all numbers as numerals.  Couchbase.Numbers      
 614:67   error  Write all numbers as numerals.  Couchbase.Numbers      
 627:56   error  Use 'Analytics Service'         Vale.Terms             
                 instead of 'Analytics                                  
                 service'.                                              
 750:7    error  Introduce links with 'For more  Couchbase.ReferTo      
                 information, see {link}'.                              
 767:249  error  Write all numbers as numerals.  Couchbase.Numbers      
 781:76   error  Write all numbers as numerals.  Couchbase.Numbers      
 793:113  error  Write all numbers as numerals.  Couchbase.Numbers      

✖ 25 errors, 0 warnings and 0 suggestions in 1 file.
```


[DOC-14284]: https://couchbasecloud.atlassian.net/browse/DOC-14284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ